### PR TITLE
Switch web bundler to webpack and update configs

### DIFF
--- a/app.config.web.js
+++ b/app.config.web.js
@@ -24,7 +24,7 @@ export default {
   },
   web: {
     favicon: './assets/favicon.png',
-    bundler: 'metro',
+    bundler: 'webpack',
     output: 'static',
     title: 'WizNote',
     // PWA configuration

--- a/metro.config.js
+++ b/metro.config.js
@@ -4,27 +4,8 @@ const { getDefaultConfig } = require('expo/metro-config');
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
 
-// Ensure proper platform extension resolution for web
-// When on web, Metro will look for files in this order:
-// 1. Component.web.tsx
-// 2. Component.tsx
-config.resolver = {
-  ...config.resolver,
-  sourceExts: ['tsx', 'ts', 'jsx', 'js', 'json', 'mjs', 'cjs'],
-  platforms: ['ios', 'android', 'web'],
-  unstable_enablePackageExports: false, // Disable package exports to avoid ESM issues
-};
-
-// Add transformer options for better compatibility
-config.transformer = {
-  ...config.transformer,
-  getTransformOptions: async () => ({
-    transform: {
-      experimentalImportSupport: false,
-      inlineRequires: true,
-    },
-  }),
-};
+// Just use default Expo config with minimal modifications
+// The .web.tsx platform-specific files will still work automatically
 
 module.exports = config;
 

--- a/package.json
+++ b/package.json
@@ -39,12 +39,6 @@
     "version:major": "npm version major",
     "version:show": "npm version --no-git-tag-version"
   },
-  "overrides": {
-    "@supabase/postgrest-js": "^1.15.8",
-    "use-latest-callback": "^0.2.1",
-    "merge-options": "^3.0.4",
-    "tslib": "^2.6.2"
-  },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -92,6 +86,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@expo/image-utils": "^0.8.7",
+    "@expo/webpack-config": "^19.0.1",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^12.9.0",
     "@types/eslint": "^9.6.1",


### PR DESCRIPTION
Changed the web bundler from Metro to Webpack in app.config.web.js and removed custom Metro config for web platform. Added @expo/webpack-config to devDependencies and removed package.json overrides for cleaner dependency management.