### PR TITLE
Add expo-crypto dependency and conditionally import for native platforms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "expo-audio": "^1.0.13",
         "expo-blur": "~15.0.7",
         "expo-constants": "~18.0.9",
+        "expo-crypto": "~15.0.1",
         "expo-dev-client": "~6.0.13",
         "expo-document-picker": "~14.0.7",
         "expo-font": "~14.0.8",
@@ -8813,6 +8814,18 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.7.tgz",
+      "integrity": "sha512-FUo41TwwGT2e5rA45PsjezI868Ch3M6wbCZsmqTWdF/hr+HyPcrp1L//dsh/hsrsyrQdpY/U96Lu71/wXePJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-dev-client": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "expo-audio": "^1.0.13",
     "expo-blur": "~15.0.7",
     "expo-constants": "~18.0.9",
+    "expo-crypto": "~15.0.1",
     "expo-dev-client": "~6.0.13",
     "expo-document-picker": "~14.0.7",
     "expo-font": "~14.0.8",

--- a/services/RequestSigningService.ts
+++ b/services/RequestSigningService.ts
@@ -10,7 +10,12 @@
 
 import { supabase } from '../lib/supabase';
 import { Platform } from 'react-native';
-import * as Crypto from 'expo-crypto';
+
+// Conditionally import expo-crypto only for native platforms
+let Crypto: any = null;
+if (Platform.OS !== 'web') {
+  Crypto = require('expo-crypto');
+}
 
 /**
  * Signed request data
@@ -98,6 +103,9 @@ class RequestSigningService {
         return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
       } else {
         // React Native using expo-crypto
+        if (!Crypto) {
+          throw new Error('expo-crypto not available on this platform');
+        }
         return await Crypto.digestStringAsync(
           Crypto.CryptoDigestAlgorithm.SHA256,
           data
@@ -134,6 +142,9 @@ class RequestSigningService {
       } else {
         // React Native - use a combination of hash and key
         // Note: For production, consider using a native crypto library
+        if (!Crypto) {
+          throw new Error('expo-crypto not available on this platform');
+        }
         const combined = `${key}:${message}`;
         return await Crypto.digestStringAsync(
           Crypto.CryptoDigestAlgorithm.SHA256,


### PR DESCRIPTION
This commit adds the expo-crypto package to package.json and package-lock.json. It also updates the RequestSigningService to conditionally import expo-crypto only for non-web platforms, ensuring compatibility and preventing errors when the library is not available.