### PR TITLE
Enhance API configuration by introducing a utility function for endpo…

### DIFF
--- a/constants/ApiConfig.ts
+++ b/constants/ApiConfig.ts
@@ -47,6 +47,13 @@ export const getWebhookBaseUrl = (): string => {
 };
 
 /**
+ * Build full API endpoint URL by appending path to base URL
+ */
+const getApiPath = (path: string): string => {
+  return `${getWebhookBaseUrl()}${path}`;
+};
+
+/**
  * API Endpoints Configuration
  */
 export const ApiConfig = {
@@ -66,21 +73,23 @@ export const ApiConfig = {
    * Stripe Endpoints
    */
   STRIPE: {
-    CREATE_PAYMENTSHEET: `${getWebhookBaseUrl()}/stripe/create-paymentsheet`,
-    CONFIRM_PAYMENTSHEET: `${getWebhookBaseUrl()}/stripe/confirm-paymentsheet`,
-    CREATE_CHECKOUT: `${getWebhookBaseUrl()}/stripe/create-checkout`,
-    VERIFY_SESSION: `${getWebhookBaseUrl()}/stripe/verify-session`,
-    CANCEL_SUBSCRIPTION: `${getWebhookBaseUrl()}/stripe/cancel-subscription`,
-    REACTIVATE_SUBSCRIPTION: `${getWebhookBaseUrl()}/stripe/reactivate-subscription`,
-    GET_BILLING_HISTORY: `${getWebhookBaseUrl()}/stripe/get-billing-history`,
+    CREATE_PAYMENTSHEET: getApiPath('/stripe/create-paymentsheet'),
+    CONFIRM_PAYMENTSHEET: getApiPath('/stripe/confirm-paymentsheet'),
+    CREATE_CHECKOUT: getApiPath('/stripe/create-checkout'),
+    VERIFY_SESSION: getApiPath('/stripe/verify-session'),
+    CANCEL_SUBSCRIPTION: getApiPath('/stripe/cancel-subscription'),
+    REACTIVATE_SUBSCRIPTION: getApiPath('/stripe/reactivate-subscription'),
+    GET_BILLING_HISTORY: getApiPath('/stripe/get-billing-history'),
+    SYNC_PLAN: getApiPath('/stripe/sync-plan'),
   },
   
   /**
    * Health Check Endpoints
    */
   HEALTH: {
-    READY: `${getWebhookBaseUrl()}/ready`,
-    HEALTH: `${getWebhookBaseUrl()}/health`,
+    READY: getApiPath('/ready'),
+    HEALTH: getApiPath('/health'),
+    SYNC_STATUS: getApiPath('/sync-status'),
   },
 };
 

--- a/docs/DUAL_STRIPE_GUARDIAN_SETUP.md
+++ b/docs/DUAL_STRIPE_GUARDIAN_SETUP.md
@@ -9,6 +9,8 @@ Wiznote now uses **two separate Stripe Guardian instances** for different enviro
 
 The app **automatically** selects the correct instance based on the build environment.
 
+**Both instances use the same server (`server.js`) and have identical API routes under `/api/`**
+
 ## How It Works
 
 ### Automatic URL Selection


### PR DESCRIPTION
…int URLs

This commit adds a new utility function, `getApiPath`, to streamline the construction of API endpoint URLs by appending paths to the base URL. The existing API endpoint definitions in the `ApiConfig` have been updated to utilize this new function, improving code maintainability and consistency. Additionally, the documentation for the dual Stripe Guardian setup has been updated to clarify that both instances share the same server and API routes.