### PR TITLE
Update webhook base URL configuration for development and production …

### DIFF
--- a/constants/ApiConfig.ts
+++ b/constants/ApiConfig.ts
@@ -37,9 +37,10 @@ export const getWebhookBaseUrl = (): string => {
     return envUrl.replace(/\/$/, '');
   }
   
-  // Development: Use Render development instance
+  // Development: Use Render instance (no /api prefix)
+  // TODO: When you deploy stripe-guardian-dev, change to that URL
   if (isDevelopment()) {
-    return 'https://stripe-guardian.onrender.com/api';
+    return 'https://stripe-guardian.onrender.com';
   }
   
   // Production: Use Starlight Hyperlift production instance
@@ -59,8 +60,8 @@ const getApiPath = (path: string): string => {
 export const ApiConfig = {
   /**
    * Stripe Guardian Webhook Base URL
-   * - Development: https://stripe-guardian.onrender.com/api
-   * - Production: https://api.webcap.media/api
+   * - Development: https://stripe-guardian.onrender.com (Render, no /api prefix)
+   * - Production: https://api.webcap.media/api (Starlight Hyperlift)
    */
   WEBHOOK_BASE_URL: getWebhookBaseUrl(),
   

--- a/env.template
+++ b/env.template
@@ -42,8 +42,8 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 # Webhook Configuration
 # OPTIONAL: Override the automatic environment-based URL selection
 # If not set, automatically uses:
-#   - Development builds: https://stripe-guardian.onrender.com/api
-#   - Production builds: https://api.webcap.media/api
+#   - Development builds: https://stripe-guardian.onrender.com (Render, no /api prefix)
+#   - Production builds: https://api.webcap.media/api (Starlight Hyperlift)
 # EXPO_PUBLIC_WEBHOOK_BASE_URL=https://api.webcap.media/api
 
 


### PR DESCRIPTION
…environments

This commit modifies the `env.template` and `ApiConfig.ts` files to clarify the webhook base URL settings. The development URL now omits the `/api` prefix for the Render instance, and the documentation has been updated accordingly. These changes enhance clarity and ensure consistency in the API configuration across different environments.